### PR TITLE
Limelight integration

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -271,6 +271,20 @@ public class Constants {
     //Name of the limelight camera.
     public static final String kLimelightName = "limelight";
 
+    //Allowable TX tolerance for aiming at an AprilTag.
+    public static final double kTXTolerance = 1;    //A complete guess.
+
+    //Distance between the center of the speaker AprilTag and the floor.
+    //The bottom of the AprilTag is 4 ft. 3-7/8 in. from the ground.
+    //Add 4-1/2 in. to the center of the AprilTag.
+    //56-3/8 in. is 1.432 meters.
+    public static final double kSpeakerAprilTagHeight = 1.432;
+    
+    //Distance between the lens of the limelight and the floor.
+    //Lens of the limelight is 16-9/10 in. from the ground.
+    //16-9/10 in. is 0.429 meters.
+    public static final double kLimelightHeight = 0.429;
+
     //Pose of the blue speaker.
     //Used to be a pose, but only the X and Y are needed.  Changed to a translation to clean up the actual calculation.
     public static final Translation2d kBlueSpeakerLocation = new Translation2d(0.0, 5.5);
@@ -282,6 +296,10 @@ public class Constants {
     //Since the driver station defaults to 'Red 1' as the alliance station when not connected to the FMS, the default pose is for the red alliance.
     //Change the rotation to 0 radians if you want the default pose to be the blue alliance.
     public static final Rotation2d kDefaultRotation = new Rotation2d(Math.PI);
+
+    static {
+        
+    }
     public static final Pose2d kDefaultPose = new Pose2d(0, 0, kDefaultRotation);
 
     //Interpolation for the shoot with pose command.  The values that correspond to shooting from the subwoofer and podium can also be added.

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -54,14 +54,14 @@ public class Constants {
     //public static final int kMotorEnableLeftRearSwerveSteer = 1;
 
     // Start Motor Enables Front Intake
-    public static final int kMotorEnableFrontIntakeSpin = 1;
-    public static final int kMotorEnableFrontIntakeRotate = 1;
+    public static final int kMotorEnableFrontIntakeSpin = 0;
+    public static final int kMotorEnableFrontIntakeRotate = 0;
 
     //Start Motor Enables Shooter
-    public static final int kMotorEnableLeftShooterSpin = 1;
-    public static final int kMotorEnableRightShooterSpin = 1;
-    public static final int kMotorEnableShooterIntakeSpin = 1;
-    public static final int kMotorEnableShooterArmRotate = 1;
+    public static final int kMotorEnableLeftShooterSpin = 0;
+    public static final int kMotorEnableRightShooterSpin = 0;
+    public static final int kMotorEnableShooterIntakeSpin = 0;
+    public static final int kMotorEnableShooterArmRotate = 0;
 
     //Start Motor Enables Climber
     public static final int kMotorEnableClimber = 0;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.LimelightHelpers.LimelightTarget_Fiducial;
 import frc.robot.LimelightHelpers.Results;
 import frc.robot.commands.General.DisabledSafety;
 import frc.robot.commands.General.NotePosition;
@@ -60,8 +61,6 @@ public class Robot extends TimedRobot {
         m_robotContainer.drivetrain.addVisionMeasurement(limelightMeasurement.pose, limelightMeasurement.timestampSeconds);
       }
 
-      //Old limelight example code.
-      //Results limelightResults = LimelightHelpers.getLatestResults(Constants.kLimelightName).targetingResults;
       //Pose2d limelightPose = limelightResults.getBotPose2d();
 
       //This validity check will probably have more logic to it in the future, but for now, just check if the latest results are valid.

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -5,6 +5,7 @@
 package frc.robot;
 
 import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
@@ -46,14 +47,21 @@ public class Robot extends TimedRobot {
 
     if (enableLimelight) {
       //Periodically retrieve the results from the limelight and extract the pose.
-      Results limelightResults = LimelightHelpers.getLatestResults(Constants.kLimelightName).targetingResults;
-      Pose2d limelightPose = limelightResults.getBotPose2d();
+      LimelightHelpers.PoseEstimate limelightMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue(Constants.kLimelightName);
+      if (limelightMeasurement.tagCount >= 2) {
+        m_robotContainer.drivetrain.setVisionMeasurementStdDevs(VecBuilder.fill(0.7, 0.7, 9999999));
+        m_robotContainer.drivetrain.addVisionMeasurement(limelightMeasurement.pose, limelightMeasurement.timestampSeconds);
+      }
+
+      //Old limelight example code.
+      //Results limelightResults = LimelightHelpers.getLatestResults(Constants.kLimelightName).targetingResults;
+      //Pose2d limelightPose = limelightResults.getBotPose2d();
 
       //This validity check will probably have more logic to it in the future, but for now, just check if the latest results are valid.
-      if (limelightResults.valid) {
+      //if (limelightResults.valid) {
         //botpose[6] is the combined targeting latency and capture latency.  Subtract from the current time to determine when the results were calculated.
         //m_robotContainer.drivetrain.addVisionMeasurement(limelightPose, Timer.getFPGATimestamp() - (limelightResults.botpose[6] / 1000));
-      }
+      //}
     }
   }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@ package frc.robot;
 import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.net.PortForwarder;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
@@ -39,6 +40,12 @@ public class Robot extends TimedRobot {
     m_robotContainer.drivetrain.seedFieldRelative(Constants.kDefaultPose);
 
     //CameraServer.startAutomaticCapture();
+
+    //Setting up port forwarding for all limelight related ports.
+    //Only setting the port-forwarding once in the code.
+    for (int port = 5800; port <= 5807; port++) {
+      PortForwarder.add(port, "limelight.local", port);
+    }
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -88,6 +88,11 @@ public class RobotContainer {
       .withDeadband(MaxSpeed * 0.1).withRotationalDeadband(MaxAngularRate * 0.1)
       .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
 
+  //Experimental Limelight targeting
+  private final SwerveRequest.FieldCentricFacingAngle limelightCentering = new SwerveRequest.FieldCentricFacingAngle()
+      .withDeadband(MaxSpeed * 0.1).withRotationalDeadband(MaxAngularRate * 0.1)
+      .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+  
   private final Telemetry logger = new Telemetry(MaxSpeed);
 
   //Open Subsystems
@@ -106,7 +111,7 @@ public class RobotContainer {
             .withVelocityY(-driveController.getLeftX() * MaxSpeed) // Drive left with negative X (left)
             .withRotationalRate(-driveController.getRightX() * MaxAngularRate) // Drive counterclockwise with negative X (left)
         ).ignoringDisable(true));
-
+    
     //=============================================================================
     //======================Driver Controller Assignments==========================
     //=============================================================================

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -32,6 +32,7 @@ import frc.robot.commands.CommandSwerveDrivetrain;
 import frc.robot.commands.Operator.PreClimb;
 import frc.robot.commands.Operator.ShooterModeAmp;
 import frc.robot.commands.Operator.ShooterModePodium;
+import frc.robot.commands.Operator.ShooterModeShootWithLimelight;
 import frc.robot.commands.Operator.ShooterModeShootWithPose;
 import frc.robot.commands.Operator.ShooterModeSubwoofer;
 import frc.robot.commands.Driver.Climb;
@@ -210,8 +211,11 @@ public class RobotContainer {
     driveController.back().and(driveController.x()).whileTrue(drivetrain.sysIdDynamic(Direction.kReverse));
     driveController.start().and(driveController.y()).whileTrue(drivetrain.sysIdQuasistatic(Direction.kForward));
     driveController.start().and(driveController.x()).whileTrue(drivetrain.sysIdQuasistatic(Direction.kReverse));
-  }
 
+    //Limelight piece-by-piece debugging
+    driveController.back().onTrue(new ShooterModeShootWithLimelight(frontIntake, shooter, drivetrain, shooterIntake));
+  }
+  
   /**
    * Add all of the subsystems to {@link SmartDashboard}, so the data is published automatically.
    */

--- a/src/main/java/frc/robot/commands/Operator/ShooterModeShootWithLimelight.java
+++ b/src/main/java/frc/robot/commands/Operator/ShooterModeShootWithLimelight.java
@@ -1,0 +1,188 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.Operator;
+
+import frc.robot.Constants;
+import frc.robot.LimelightHelpers;
+import frc.robot.commands.CommandSwerveDrivetrain;
+import frc.robot.generated.TunerConstants;
+import frc.robot.subsystems.ShooterSubsystem;
+
+import com.ctre.phoenix6.mechanisms.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.mechanisms.swerve.SwerveRequest;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.FrontIntakeSubsystem;
+import frc.robot.subsystems.ShooterIntakeSubsystem;
+
+/**
+* Aims with limelight
+*/
+public class ShooterModeShootWithLimelight extends Command {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  
+  private final FrontIntakeSubsystem m_frontIntakeSubsystem;
+  private final ShooterSubsystem m_shooterSubsystem;
+  private final CommandSwerveDrivetrain m_drivetrain;
+  private final ShooterIntakeSubsystem m_shooterIntakeSubsystem;
+
+  private final SwerveRequest.FieldCentricFacingAngle m_aim = new SwerveRequest.FieldCentricFacingAngle()
+  .withDeadband((TunerConstants.kSpeedAt12VoltsMps) * 0.1)
+  .withRotationalDeadband((1.5 * Math.PI) * 0.1)
+  .withDriveRequestType(DriveRequestType.OpenLoopVoltage)
+  .withVelocityX(0)
+  .withVelocityY(0);
+
+  /*
+   * Check for Fiducal 'Whatever it is (7?)'                            CASE 1
+   * If present, get TX - If not, quit command (or signal in some way)  CASE 1
+   * Add (or subtract) TX as angle, to / from current robot angle       CASE 1
+   * That is your setpoint                                              CASE 1
+   * Set swerve control the face the setpoint angle
+   * Do so until TX is 0, or near 0
+   */
+  
+  private boolean m_isFinished = false;
+  private int m_stateMachine = 1;
+  private double m_shooterPoseSpeed = 0;
+  private double m_shooterArmPosePos = 0;
+  private double m_distanceToAprilTag = 0;
+  private double m_angleToAprilTag = 0;
+  private double m_currentRobotHeading = 0;
+  private double m_newAngleHeading = 0;
+  private int m_debounceCounter = 0;
+  private int m_debounceLimit = 0;
+  private Rotation2d m_limeLightRotation;
+  private double m_limeLightToAprilTagVerticalDistance = (Constants.kSpeakerAprilTagHeight - Constants.kLimelightHeight);
+  private double m_verticalAngleToAprilTag = 0;
+
+  /**
+   * Constructs an instance of the aim with limelight command.
+   * @param frontIntakeSubsystem An instance of the front intake subsystem.
+   * Required.
+   * @param shooterSubsystem An instance of the shooter subsystem.
+   * Required.
+   * @param drivetrain An instance of the drivetrain subsystem.
+   * Required.
+   */
+  public ShooterModeShootWithLimelight(FrontIntakeSubsystem frontIntakeSubsystem, ShooterSubsystem shooterSubsystem, CommandSwerveDrivetrain drivetrain, ShooterIntakeSubsystem shooterIntakeSubsystem) {
+    m_shooterSubsystem = shooterSubsystem;
+    m_frontIntakeSubsystem = frontIntakeSubsystem;
+    m_drivetrain = drivetrain;
+    m_shooterIntakeSubsystem = shooterIntakeSubsystem;
+
+    m_aim.HeadingController.setPID(20, 0, 0.05);
+
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(m_shooterSubsystem);
+    addRequirements(m_frontIntakeSubsystem);
+    addRequirements(m_drivetrain);
+    addRequirements(m_shooterIntakeSubsystem);
+  }
+
+  public Rotation2d helpMe(double degrees) {
+    return new Rotation2d(degrees);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+ 
+    System.out.println("==========================");
+    System.out.println("Command Operator: AimWithLimelight");
+   
+    //Initialize State Machine
+    m_stateMachine = 1;
+
+    m_debounceCounter = 0;
+    m_debounceLimit = 0;
+    
+    //Set initial speeds and positions
+    //m_frontIntakeSubsystem.setFrontIntakePosition(Constants.kFrontIntakeClearPos);
+    //m_shooterSubsystem.setShooterMode("ShootWithPose");
+
+    m_isFinished = false;
+
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+
+    //We should be calculating the pose requirements here over and over.
+    //m_distanceToSubwoofer = Constants.kBlueSpeakerLocation.getDistance(m_drivetrain.getState().Pose.getTranslation());
+    //m_shooterPoseSpeed = Constants.kShooterSpeedTable.get(m_distanceToSubwoofer);
+    //m_shooterArmPosePos = Constants.kShooterArmTable.get(m_distanceToSubwoofer);
+
+    switch(m_stateMachine) {     
+      case 1:  // Search for AprilTag
+        System.out.println("AimWithLimelight - Case 1 - Search for AprilTag");
+        
+        if (LimelightHelpers.getTV(Constants.kLimelightName)) {//As I understand, the pipeline defines the AprilTag to look for.  There may be a way to further refine.
+          System.out.println("AimWithLimelight - Case 1 - AprilTag found!");
+          //Get angles.
+          m_angleToAprilTag = LimelightHelpers.getTX(Constants.kLimelightName);
+          m_currentRobotHeading = m_drivetrain.getState().Pose.getRotation().getDegrees();
+          //m_currentRobotHeading = m_drivetrain.getPigeon2().getRotation2d().getDegrees(); Alternate if above doesn't work.
+          m_newAngleHeading = m_angleToAprilTag + m_currentRobotHeading;
+          m_limeLightRotation = helpMe(m_newAngleHeading);
+
+          m_verticalAngleToAprilTag = LimelightHelpers.getTY(Constants.kLimelightName);
+          m_distanceToAprilTag = m_limeLightToAprilTagVerticalDistance / Math.tan(m_verticalAngleToAprilTag);
+
+          m_stateMachine = m_stateMachine + 1;
+        }
+        else {//Stop the command.
+          System.out.println("AimWithLimelight - Case 1 - No AprilTag found!");
+          //Signal to the driver with the LEDs, or something.
+          m_isFinished = true;
+        }        
+        break;
+
+      case 2:  //Rotate to the new angle.
+        System.out.println("AimWithLimelight - Case 2 - Rotate to position");
+        m_drivetrain.setControl(m_aim.withTargetDirection(m_limeLightRotation));
+        if (Math.abs(LimelightHelpers.getTX(Constants.kLimelightName)) <= Constants.kTXTolerance) {
+          if (m_debounceCounter >= m_debounceLimit) {
+            m_stateMachine = m_stateMachine + 1;
+          } else {
+            m_debounceCounter++;
+          }
+          System.out.println("AimWithLimelight - Case 2 - Properly rotated!");
+        }
+        else {
+          m_debounceCounter = 0;
+        }
+        break;
+
+      case 3: //Set arm to proper position and spin up shooter
+        m_shooterSubsystem.setShooterArmPosition(m_shooterArmPosePos);
+        m_shooterSubsystem.setShooterSpeed(m_shooterPoseSpeed);
+        if (m_shooterSubsystem.getShooterArmInPosition(m_shooterArmPosePos)) {
+          m_stateMachine = m_stateMachine + 1;
+        }
+        break;
+
+      case 4:
+        if (m_shooterSubsystem.getShooterUpToSpeed(m_shooterPoseSpeed)) {
+          m_shooterIntakeSubsystem.setShooterIntakeSpeed(Constants.kShooterIntakeShootSpeed);
+        }
+    }
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    System.out.println("Command Operator ShooerModeShootWithPose: Finished");
+    System.out.println("==========================");
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return m_isFinished;
+  }
+}

--- a/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/src/main/java/frc/robot/generated/TunerConstants.java
@@ -33,7 +33,7 @@ public class TunerConstants {
 
     // The stator current at which the wheels start to slip;
     // This needs to be tuned to your individual robot
-    private static final double kSlipCurrentA = 300.0;
+    private static final double kSlipCurrentA = 80.0;
 
     // Theoretical free speed (m/s) at 12v applied output;
     // This needs to be tuned to your individual robot

--- a/vendordeps/PathplannerLib.json
+++ b/vendordeps/PathplannerLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "PathplannerLib.json",
     "name": "PathplannerLib",
-    "version": "2024.2.3",
+    "version": "2024.2.4",
     "uuid": "1b42324f-17c6-4875-8e77-1c312bc8c786",
     "frcYear": "2024",
     "mavenUrls": [
@@ -12,7 +12,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-java",
-            "version": "2024.2.3"
+            "version": "2024.2.4"
         }
     ],
     "jniDependencies": [],
@@ -20,7 +20,7 @@
         {
             "groupId": "com.pathplanner.lib",
             "artifactId": "PathplannerLib-cpp",
-            "version": "2024.2.3",
+            "version": "2024.2.4",
             "libName": "PathplannerLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Code from the latest limelight integration.  The pose should be periodically updated with the limelight pose if more than 2 targets are seen.  Also, the shoot with pose uses the limelight TX to rotate the robot to the center of the AprilTag, but it needs tuning.

And we made it without a single reference to <i>Limelight</i> by RUSH.